### PR TITLE
etcd moving to etcd.io from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ When listing/deleting a directory, e3ch will get key-value with the prefix. For 
 package main
 
 import (
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	"github.com/soyking/e3ch"
 )
 

--- a/auth.go
+++ b/auth.go
@@ -3,8 +3,8 @@ package client
 import (
 	"strings"
 
-	"github.com/coreos/etcd/auth/authpb"
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/auth/authpb"
+	"go.etcd.io/etcd/clientv3"
 )
 
 func (clt *EtcdHRCHYClient) permPath(key string) (string, error) {

--- a/auth_test.go
+++ b/auth_test.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"encoding/json"
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	. "gopkg.in/check.v1"
 )
 

--- a/client.go
+++ b/client.go
@@ -2,8 +2,8 @@ package client
 
 import (
 	"errors"
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/mvcc/mvccpb"
+	"go.etcd.io/etcd/clientv3"
+	mvccpb "go.etcd.io/etcd/mvcc/mvccpb"
 	"golang.org/x/net/context"
 	"strings"
 )

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	. "gopkg.in/check.v1"
 	"testing"
 )

--- a/create_test.go
+++ b/create_test.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	. "gopkg.in/check.v1"
 )
 

--- a/delete.go
+++ b/delete.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 )
 
 // list a directory

--- a/delete_test.go
+++ b/delete_test.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	. "gopkg.in/check.v1"
 	"strconv"
 )

--- a/get_test.go
+++ b/get_test.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	. "gopkg.in/check.v1"
 )
 

--- a/list.go
+++ b/list.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/mvcc/mvccpb"
+	"go.etcd.io/etcd/clientv3"
+	mvccpb "go.etcd.io/etcd/mvcc/mvccpb"
 	"strings"
 )
 

--- a/list_test.go
+++ b/list_test.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"encoding/json"
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	. "gopkg.in/check.v1"
 	"strconv"
 )

--- a/put.go
+++ b/put.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 )
 
 // set kv or directory

--- a/put_test.go
+++ b/put_test.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	. "gopkg.in/check.v1"
 )
 


### PR DESCRIPTION
etcd moving to etcd.io from github. I updated the imports to  new address (etcd.io). I think some projects will need to be updated. i'm getting this error when use this package with etcd new client("go.etcd.io/etcd/clientv3") :
`github.com/soyking/e3ch/get.go:19:32: 
cannot use resp.Kvs[0] (type *"go.etcd.io/etcd/mvcc/mvccpb".KeyValue) as type
 *"github.com/coreos/etcd/mvcc/mvccpb".KeyValue 
in argument to clt.createNode`